### PR TITLE
Remove CSV Messaging For Options Fields

### DIFF
--- a/app/views/workarea/admin/create_catalog_product_kits/edit_variant.html.haml
+++ b/app/views/workarea/admin/create_catalog_product_kits/edit_variant.html.haml
@@ -62,11 +62,6 @@
                 .property
                   = text_field_tag 'new_details[]', nil, id: nil, class: 'text-box text-box--i18n', title: t('workarea.admin.catalog_variants.new.options.new_attribute_value'), placeholder: t('workarea.admin.catalog_variants.new.options.new_attribute_value_placeholder')
                   %span.property__note= t('workarea.admin.catalog_variants.new.options.new_attribute_value_note')
-                  %span.property__note
-                    = t('workarea.admin.catalog_variants.new.options.new_attribute_value_csv')
-                    = link_to '#csv-help', data: { tooltip: '' } do
-                      = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.catalog_variants.new.options.learn_more'))
-                  = render 'workarea/admin/shared/csv_formatting_tooltip'
               %td.align-center -
 
         = render 'workarea/admin/catalog_variants/components', product: @product, variant: @variant


### PR DESCRIPTION
When workarea-commerce/workarea#497 is merged, this will ensure that the product bundles plugin is not attempting to use a translation that is no longer there. It also brings the plugin to parity with the core functionality of editing options.