### PR TITLE
Fix Error on Missing Components Params

### DIFF
--- a/app/services/workarea/build_kit_variants.rb
+++ b/app/services/workarea/build_kit_variants.rb
@@ -38,6 +38,7 @@ module Workarea
     def component_groups
       return @component_groups if defined?(@component_groups)
       pieces = params.components
+      return [] unless pieces.present?
       @component_groups = pieces.shift.product(*pieces)
     end
 

--- a/test/services/workarea/build_kit_variants_test.rb
+++ b/test/services/workarea/build_kit_variants_test.rb
@@ -263,5 +263,21 @@ module Workarea
       refute(summary.duplicate_details?)
       assert(summary.invalid_details?)
     end
+
+    def test_component_groups
+      kit = create_product(
+        name: 'Test Kit',
+        variants: [],
+        product_ids: %w(PROD1 PROD2)
+      )
+      build = BuildKitVariants.new(kit, params)
+
+      refute_empty(build.component_groups)
+      assert_kind_of(Hash, build.component_groups.first.first)
+
+      build = BuildKitVariants.new(kit, params.merge(components: { '1' => {} }))
+
+      assert_empty(build.component_groups)
+    end
   end
 end


### PR DESCRIPTION
The `:components` param sent into `BuildKitVariants` can point to empty hashes. If this is the case, ensure that `#component_groups` does not throw an error, but rather returns an empty Array so downstream consumers can handle the situation gracefully.